### PR TITLE
fix(csp): whitelist unpkg + Google Fonts in production CSP

### DIFF
--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -25,10 +25,10 @@ class SecurityHeadersMiddleware:
 
     CSP = (
         "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline'; "
-        "style-src 'self' 'unsafe-inline'; "
+        "script-src 'self' 'unsafe-inline' https://unpkg.com; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         "img-src 'self' data:; "
-        "font-src 'self'; "
+        "font-src 'self' https://fonts.gstatic.com; "
         "connect-src 'self'; "
         "frame-ancestors 'none';"
     )


### PR DESCRIPTION
Prod CSP only allowed 'self' for script-src/style-src/font-src, blocking https://unpkg.com/lucide (icons), fonts.googleapis.com (CSS), and fonts.gstatic.com (woff2). Missing lucide cascades: sidebar toggle / theme / language handlers call lucide.createIcons() which is undefined when the script fails to load.