### PR TITLE
infra: migrate Render resources to Frankfurt (EU) region

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,22 +1,39 @@
 databases:
-  - name: teachkadb
-    plan: free
-    databaseName: teachka
-    user: teachka
+  # Created + restored manually in Frankfurt. Blueprint adopts it by name.
+  - name: teachka-db-eu
+    plan: basic_256mb
+    region: frankfurt
+    databaseName: teachkadbeu
+    user: teachkadbeu_user
 
 services:
-  - type: web
+  # New Frankfurt redis (for live-play / Channels). None existed before.
+  - type: keyvalue
+    name: teachka-redis-eu
     plan: free
-    name: teachka-web
+    region: frankfurt
+    ipAllowList: []  # only reachable from Render services
+
+  # New Frankfurt web service. Old Oregon `teachka-web` keeps serving
+  # teachka.com until you move the custom domain here, then delete it.
+  - type: web
+    plan: starter
+    name: teachka-web-eu
+    region: frankfurt
     runtime: python
     buildCommand: './build.sh'
     startCommand: 'python -m gunicorn teachkaBaseProject.asgi:application -k uvicorn.workers.UvicornWorker'
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: teachkadb
+          name: teachka-db-eu
           property: connectionString
       - key: SECRET_KEY
         generateValue: true
       - key: WEB_CONCURRENCY
         value: 4
+      - key: REDIS_URL
+        fromService:
+          type: keyvalue
+          name: teachka-redis-eu
+          property: connectionString


### PR DESCRIPTION
Move Postgres, web, and a new keyvalue (redis) service to the frankfurt region for EU data residency. DB (teachka-db-eu) already provisioned and restored; blueprint adopts it. Web + redis get new names since Render region is immutable on existing resources.