### PR TITLE
ci: read deploy secrets from the main environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Secrets (DEPLOY_*) live in this GitHub Environment, not at repo level.
+    environment: "main - teachka-web-eu"
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
Secrets are scoped to the "main - teachka-web-eu" GitHub Environment; the job must declare it or the DEPLOY_* values arrive empty.