### PR TITLE
Quiz reveal + live image focus fixes

### DIFF
--- a/apps/quizzmaker/live.py
+++ b/apps/quizzmaker/live.py
@@ -581,6 +581,8 @@ def _public_round(round_def: dict[str, Any], show_question: bool) -> dict[str, A
     if show_question:
         data["question"] = round_def["question"]
         data["image_url"] = round_def.get("image_url", "")
+        data["focus_x"] = round_def.get("focus_x", 50)
+        data["focus_y"] = round_def.get("focus_y", 50)
     return data
 
 
@@ -615,6 +617,8 @@ def state_payload(code: str, *, role: str, token: str | None = None) -> dict[str
                 "points": rdef["points"],
                 "time_limit": rdef["time_limit"],
                 "image_url": rdef.get("image_url", ""),
+                "focus_x": rdef.get("focus_x", 50),
+                "focus_y": rdef.get("focus_y", 50),
                 "single_select": rdef.get("single_select", False),
                 "answers": [{"id": a["id"], "text": a["text"]} for a in rdef.get("answers", [])],
             }

--- a/apps/quizzmaker/templates/quizzmaker/session_host.html
+++ b/apps/quizzmaker/templates/quizzmaker/session_host.html
@@ -100,7 +100,8 @@
   "pick_all": "{% trans 'Pick all that apply' %}",
   "standings": "{% trans 'Standings' %}",
   "all_answers": "{% trans 'All answers' %}",
-  "no_answers": "{% trans 'No answers submitted' %}"
+  "no_answers": "{% trans 'No answers submitted' %}",
+  "show_all_answers": "{% trans 'Show all accepted answers' %}"
 }
 </script>
 
@@ -237,8 +238,9 @@
         <div id="timer-fill" class="h-full rounded-full" style="width:100%;background:var(--color-primary);transition:width .25s linear;"></div></div>`));
     }
     if (r.image_url) {
+      const pos = `${r.focus_x ?? 50}% ${r.focus_y ?? 50}%`;
       node.appendChild(el(`<figure class="w-full max-w-3xl mx-auto aspect-video bg-base-200 rounded-2xl overflow-hidden">
-        <img src="${r.image_url}" class="w-full h-full object-cover" /></figure>`));
+        <img src="${r.image_url}" class="w-full h-full object-cover" style="object-position:${pos}" /></figure>`));
     }
     if (r.question_type === "type_input") {
       node.appendChild(el(`<p class="text-center text-base-content/50 text-lg">{% trans "Players type their answer" %}</p>`));
@@ -279,12 +281,23 @@
       node.appendChild(answersListEl(rev.answers_list || []));
     } else if (r.question_type === "type_input") {
       const d = rev.distribution || { right: 0, wrong: 0 };
-      node.appendChild(el(`
+      const texts = rev.correct_texts || [];
+      // Show only the first accepted answer; host can reveal the rest on demand.
+      const block = el(`
         <div class="text-center space-y-2">
           <p class="text-[11px] tracking-[2px] uppercase text-base-content/40">${T.correct}</p>
-          <p class="serif text-3xl text-primary font-medium">${esc((rev.correct_texts || []).join("   ·   "))}</p>
+          <p data-correct-text class="serif text-3xl text-primary font-medium">${esc(texts[0] || "")}</p>
           <p class="text-sm text-base-content/60">${d.right} ${T.right} · ${d.wrong} ${T.wrong}</p>
-        </div>`));
+        </div>`);
+      if (texts.length > 1) {
+        const more = el(`<button class="btn-as-link-ghost mx-auto">${T.show_all_answers} (${texts.length})</button>`);
+        more.addEventListener("click", () => {
+          block.querySelector("[data-correct-text]").textContent = texts.join("   ·   ");
+          more.remove();
+        });
+        block.appendChild(more);
+      }
+      node.appendChild(block);
     } else {
       const counts = (rev.distribution && rev.distribution.counts) || {};
       const correct = new Set(rev.correct_ids || []);

--- a/apps/quizzmaker/templates/quizzmaker/session_play.html
+++ b/apps/quizzmaker/templates/quizzmaker/session_play.html
@@ -181,8 +181,9 @@
     // Timer bar sits between the question and the image.
     wrap.appendChild(timerBar(r));
     if (r.image_url) {
+      const pos = `${r.focus_x ?? 50}% ${r.focus_y ?? 50}%`;
       wrap.appendChild(el(`<figure class="w-full max-w-md mx-auto aspect-video bg-base-200 rounded-2xl overflow-hidden">
-        <img src="${r.image_url}" class="w-full h-full object-cover" /></figure>`));
+        <img src="${r.image_url}" class="w-full h-full object-cover" style="object-position:${pos}" /></figure>`));
     }
 
     if (r.question_type === "type_input") {


### PR DESCRIPTION
## Changes
- **type_input reveal**: shows only the first accepted answer alongside right/wrong counts; host gets a **Show all accepted answers** button to reveal the rest on demand.
- **Live image focus**: round `focus_x/focus_y` now travel into the host + player play payloads and are applied via `object-position`, so the live crop matches the editor preview (previously center-cropped).

## Notes
- Focus is frozen into the Redis snapshot at host time → applies to sessions hosted after deploy.
- 83 quizzmaker tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)